### PR TITLE
[THOUG-1459][Atul] Add api docs for the optional param added

### DIFF
--- a/source/includes/_enrichment.md
+++ b/source/includes/_enrichment.md
@@ -5,6 +5,7 @@
 ```shell
 curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
     "api_key": "YOUR API KEY HERE",
+    "reveal_personal_emails": true,
     "details": [
         {
             "first_name": "Tim",
@@ -30,6 +31,7 @@ url = "https://api.apollo.io/api/v1/people/bulk_match"
 
 data = {
     "api_key": "YOUR API KEY HERE",
+    "reveal_personal_emails": true,
     "details": [
         {
             "first_name": "Tim",
@@ -385,6 +387,10 @@ print(response.text)
             }
          ]
       }
+   ], 
+   "personal_emails": [
+       "personalemail1@domain.com",
+       "personalemail2@domain.com"
    ]
 }
 ```
@@ -396,7 +402,7 @@ Up to 10 records can be enriched at the same time through this endpoint.
 
 ### Credit Usage
 
-The enrich endpoint charges you credits for its usage. If a verified email is successfully returned, it will cost you 1 credit. If an email is not found, but Apollo successfully found ALL of the following information: Name, Linkedin Profile, Current Company Information, Apollo will charge a fraction of a credit. Typically this is 0.01 credit per successful enrichment without email. But it may be higher depending on your specific plan.
+The enrich endpoint charges you credits for its usage. If a verified email is successfully returned or the list of personal emails is revealed, it will cost you 1 credit. If an email is not found, but Apollo successfully found ALL of the following information: Name, Linkedin Profile, Current Company Information, Apollo will charge a fraction of a credit. Typically this is 0.01 credit per successful enrichment without email. But it may be higher depending on your specific plan.
 
 
 Duplicate enrichments of the same record will not be charged credits. 
@@ -418,6 +424,7 @@ email (optional) | The person's email | example@domani.com
 organization_name (optional) | The person's company name | Apollo Inc.
 domain (optional) | The person's company domain | apollo.io
 id (optional) |  The person's ID obtained from the search endpoint | "583f2f7ed9ced98ab5bfXXXX"
+reveal_personal_emails (optional) | Flag to reveal personal emails | true
 
 
 ## Bulk Organization Enrichment
@@ -805,7 +812,8 @@ curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d
     "last_name": "Zheng",
     "organization_name": "Apollo",
     "email": "name@domain.io",
-    "domain": "apollo.io"
+    "domain": "apollo.io",
+    "reveal_personal_emails": true
 }' "https://api.apollo.io/v1/people/match"
 ```
 
@@ -821,7 +829,8 @@ data = {
     "last_name": "Zheng",
     "organization_name": "Apollo",
     "email": "name@domain.io",
-    "domain": "apollo.io"
+    "domain": "apollo.io",
+    "reveal_personal_emails": true
 }
 
 headers = {
@@ -1017,14 +1026,18 @@ print(response.text)
                    ...
                 }
             ]
-        }
+        },
+        "personal_emails": [
+            "personalemail1@domain.com",
+            "personalemail2@domain.com"
+        ]
     }
 }
 ```
 
 This endpoint enriches a person's information, the more information you pass in, the more likely we can find a match.  
 
-The enrich endpoint charges you credits for its usage. If a verified email is successfully returned, it will cost you 1 credit. If an email is not found, but Apollo successfully found ALL of the following information: Name, Linkedin Profile, Current Company Information, Apollo will charge a fraction of a credit. Typically this is 0.01 credit per successful enrichment without email. But it may be higher depending on your specific plan.
+The enrich endpoint charges you credits for its usage. If a verified email is successfully returned or the list of personal emails is revealed, it will cost you 1 credit. If an email is not found, but Apollo successfully found ALL of the following information: Name, Linkedin Profile, Current Company Information, Apollo will charge a fraction of a credit. Typically this is 0.01 credit per successful enrichment without email. But it may be higher depending on your specific plan.
 
 The enrich endpoint charges credits even if the person is already in your CRM. The enrich endpoint also charges credits if you pass in the same information multiple times.
 
@@ -1041,6 +1054,7 @@ email (optional) | The person's email | example@domani.com
 organization_name (optional) | The person's company name | Apollo Inc.
 domain (optional) | The person's company domain | apollo.io
 id (optional) |  The person's ID obtained from the search endpoint | "583f2f7ed9ced98ab5bfXXXX"
+reveal_personal_emails (optional) | Flag to reveal personal emails | true
 
 
 ## Organization Enrichment

--- a/source/includes/_enrichment.md
+++ b/source/includes/_enrichment.md
@@ -12,12 +12,16 @@ curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d
             "last_name": "Zheng",
             "domain": "apollo.io",
             "email": "tim@apollo.io",
+            "email_md5": "8d935115b9ff4489f2d1f9249503cadf",
+            "email_sha256": "337dc0c1aad74f93af086dcf7dc0289f141c8ef5f44c3f104f07b0f03050ff49",
             "organization_name": "Apollo"
         },
         {
             "first_name": "Roy",
             "last_name": "Chung",
             "email": "roy@apollo.io",
+            "email_md5": "7328fddefd53de471baeb6e2b764f78a",
+            "email_sha256": "97817c0c49994eb500ad0a5e7e2d8aed51977b26424d508f66e4e8887746a152",
             "organization_name": "Apollo"
         }
     ]
@@ -37,6 +41,8 @@ data = {
             "first_name": "Tim",
             "last_name": "Zheng",
             "domain": "apollo.io",
+            "email_md5": "8d935115b9ff4489f2d1f9249503cadf",
+            "email_sha256": "337dc0c1aad74f93af086dcf7dc0289f141c8ef5f44c3f104f07b0f03050ff49",
             "email": "tim@apollo.io",
             "organization_name": "Apollo"
         },
@@ -44,6 +50,8 @@ data = {
             "first_name": "Roy",
             "last_name": "Chung",
             "email": "roy@apollo.io",
+            "email_md5": "7328fddefd53de471baeb6e2b764f78a",
+            "email_sha256": "97817c0c49994eb500ad0a5e7e2d8aed51977b26424d508f66e4e8887746a152",
             "organization_name": "Apollo"
         }
     ]
@@ -421,6 +429,8 @@ first_name (optional) | The person's first name | Tim
 last_name (optional) | The person's last name | Zheng
 name (optional) | The person's full name | Tim Zheng
 email (optional) | The person's email | example@domani.com
+email_md5 (optional) | The person's hashed email | 8d935115b9ff4489f2d1f9249503cadf
+email_sha256 (optional) | The person's sha 256 hashed email | 97817c0c49994eb500ad0a5e7e2d8aed 51977b26424d508f66e4e8887746a152
 organization_name (optional) | The person's company name | Apollo Inc.
 domain (optional) | The person's company domain | apollo.io
 id (optional) |  The person's ID obtained from the search endpoint | "583f2f7ed9ced98ab5bfXXXX"
@@ -812,6 +822,8 @@ curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d
     "last_name": "Zheng",
     "organization_name": "Apollo",
     "email": "name@domain.io",
+    "email_md5": "8d935115b9ff4489f2d1f9249503cadf",
+    "email_sha256": "337dc0c1aad74f93af086dcf7dc0289f141c8ef5f44c3f104f07b0f03050ff49",
     "domain": "apollo.io",
     "reveal_personal_emails": true
 }' "https://api.apollo.io/v1/people/match"
@@ -829,6 +841,8 @@ data = {
     "last_name": "Zheng",
     "organization_name": "Apollo",
     "email": "name@domain.io",
+    "email_md5": "8d935115b9ff4489f2d1f9249503cadf",
+    "email_sha256": "337dc0c1aad74f93af086dcf7dc0289f141c8ef5f44c3f104f07b0f03050ff49",
     "domain": "apollo.io",
     "reveal_personal_emails": true
 }
@@ -1051,6 +1065,8 @@ first_name (optional) | The person's first name | Tim
 last_name (optional) | The person's last name | Zheng
 name (optional) | The person's full name | Tim Zheng
 email (optional) | The person's email | example@domani.com
+email_md5 (optional) | The person's hashed email | 8d935115b9ff4489f2d1f9249503cadf 
+email_sha256 (optional) | The person's sha 256 hashed email | 97817c0c49994eb500ad0a5e7e2d8aed 51977b26424d508f66e4e8887746a152
 organization_name (optional) | The person's company name | Apollo Inc.
 domain (optional) | The person's company domain | apollo.io
 id (optional) |  The person's ID obtained from the search endpoint | "583f2f7ed9ced98ab5bfXXXX"


### PR DESCRIPTION
**Screenshots:**
<img width="1581" alt="Screenshot 2023-02-07 at 10 42 32 PM" src="https://user-images.githubusercontent.com/120726098/217315753-ff4c317a-c36d-4bea-82ce-051a0fad0ed0.png">
<img width="1590" alt="Screenshot 2023-02-07 at 10 42 48 PM" src="https://user-images.githubusercontent.com/120726098/217315799-a2360e6d-b226-49c2-bcd9-65c6dd21ad91.png">

**Note:**
- As suggested by @VinayApollo I have added email_md5 and email_sha256 in the request body as optional params which were missed before

Make sure you've checked off all these things before submitting:

- [ ] This pull request isn't for a company's fork, it's intended for the upstream Slate shared by everybody.
- [ ] This pull request is submitted to the `master` branch.
- [ ] If it makes frontend changes, this pull request has been tested in the latest version of Firefox, Chrome, IE, and Safari.
