### PR TITLE
[LD-923] Restricting APIs to reveal personal-emails for GDPR people

### DIFF
--- a/source/includes/_enrichment.md
+++ b/source/includes/_enrichment.md
@@ -1,4 +1,4 @@
-# Enrichment API
+w# Enrichment API
 
 ## Bulk people enrichment
 
@@ -533,7 +533,7 @@ organization_name (optional) | The person's company name | Apollo Inc.
 domain (optional) | The person's company domain | apollo.io
 id (optional) |  The person's ID obtained from the search endpoint | "583f2f7ed9ced98ab5bfXXXX"
 linkedin_url (optional) | The person's linkedin URL | http://www.linkedin.com/in/tim-zheng
-reveal_personal_emails (optional) | Flag to reveal personal emails | true
+reveal_personal_emails (optional) | Flag to reveal personal emails. Note: Personal emails will not be revelead for GDPR compliant regions | true
 reveal_phone_number (optional) | Flag to reveal phone number | true
 webhook_url (optional) | Webhook URL for sending 'reveal_phone_number' response | "https://example.com/hook"
 
@@ -1204,7 +1204,7 @@ organization_name (optional) | The person's company name | Apollo Inc.
 domain (optional) | The person's company domain | apollo.io
 id (optional) |  The person's ID obtained from the search endpoint | "583f2f7ed9ced98ab5bfXXXX"
 linkedin_url (optional) | The person's linkedin URL | http://www.linkedin.com/in/tim-zheng
-reveal_personal_emails (optional) | Flag to reveal personal emails | true
+reveal_personal_emails (optional) | Flag to reveal personal emails. Note: Personal emails will not be revealed for GDPR compliant regions | true
 reveal_phone_number (optional) | Flag to reveal phone number | true
 webhook_url (optional) | Webhook URL for sending 'reveal_phone_number' response | "https://example.com/hook"
 


### PR DESCRIPTION
**Sample Renders**

<img width="714" alt="People Match" src="https://github.com/apolloio/apollo-api-docs/assets/7835583/83295fe1-b44e-4719-81c3-9e2f4f36e126">

<img width="678" alt="People Bulk Match" src="https://github.com/apolloio/apollo-api-docs/assets/7835583/6155beab-f746-4241-a494-d03cd269116f">


Make sure you've checked off all these things before submitting:

- [x] This pull request isn't for a company's fork, it's intended for the upstream Slate shared by everybody.
- [x] This pull request is submitted to the `master` branch.
- [x] If it makes frontend changes, this pull request has been tested in the latest version of Firefox, Chrome, IE, and Safari.
- [ ] If it is an API related fix, the shell and python code have been tested
