### PR TITLE
[LD-1127] Add Error Code Glossary on API Docs

### DIFF
--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -1,11 +1,12 @@
 # Errors
 
-<aside class="notice">This error section is stored in a separate file in `includes/_errors.md`. Slate allows you to optionally separate out your docs into many files...just save them to the `includes` folder and add them to the top of your `index.md`'s frontmatter. Files are included in the order listed.</aside>
+A valid API Key is required for processing API requests. 
 
-The Kittn API uses the following error codes:
+<!-- 
+The Kittn API uses the following error codes: -->
 
 
-Error Code | Meaning
+<!-- Error Code | Meaning
 ---------- | -------
 400 | Bad Request -- Your request sucks
 401 | Unauthorized -- Your API key is wrong
@@ -17,4 +18,23 @@ Error Code | Meaning
 418 | I'm a teapot
 429 | Too Many Requests -- You're requesting too many kittens! Slow down!
 500 | Internal Server Error -- We had a problem with our server. Try again later.
-503 | Service Unavailable -- We're temporarially offline for maintanance. Please try again later.
+503 | Service Unavailable -- We're temporarially offline for maintanance. Please try again later. -->
+
+
+> Sample response:
+
+```json
+{
+    "status": 401,
+    "message": "Invalid access credentials."
+}
+```
+
+
+`status`    | Example `message`                                               | Reason
+------------|  -------------------------------                                |----------
+401         |  Invalid access credentials.                                    | The API key is not valid
+403         |  This endpoint is only available to Apollo users on paid plans. | The API key is not authorized to perform the action
+429         | The maximum number of api calls allowed for `endpoint`  is `x` times per `t`. Please upgrade your plan from https://app.apollo.io/#/settings/plans/upgrade.   | The team with the API key has been rate-limited. We also send the usage in the headers in this
+
+

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -12,6 +12,7 @@ includes:
   - introduction
   - authentication
   - ratelimits
+  - errors
   - enrichment
   - people
   - organizations


### PR DESCRIPTION
Make sure you've checked off all these things before submitting:
https://apollopde.atlassian.net/browse/LD-1127
- [x] This pull request isn't for a company's fork, it's intended for the upstream Slate shared by everybody.
- [x] This pull request is submitted to the `master` branch.
- [x] If it makes frontend changes, this pull request has been tested in the latest version of Firefox, Chrome, IE, and Safari.
- [x] If it is an API related fix, the shell and python code have been tested
<img width="1486" alt="Screenshot 2024-03-11 at 5 24 27 PM" src="https://github.com/apolloio/apollo-api-docs/assets/54931749/2f62e6a7-3e92-4078-91d7-e00857115896">
