### PR TITLE
[INCIDENT-8514] - Api Documentation Update for Api Key via Request Headers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     execjs (2.7.0)
     fast_blank (1.0.0)
     fastimage (2.2.0)
-    ffi (1.13.1)
+    ffi (1.16.3)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     execjs (2.7.0)
     fast_blank (1.0.0)
     fastimage (2.2.0)
-    ffi (1.16.3)
+    ffi (1.13.1)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt

--- a/source/includes/_accounts.md
+++ b/source/includes/_accounts.md
@@ -7,8 +7,7 @@ An account is a company your team has explicitly added to your database. It can 
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "name": "Google",
     "domain": "google.com",
     "phone_number": "1-866-246-6453",
@@ -22,7 +21,6 @@ import requests
 url = "https://api.apollo.io/v1/accounts"
 
 data = {
-  "api_key": "YOUR API KEY HERE",
     "name": "Google",
     "domain": "google.com",
     "phone_number": "1-866-246-6453",
@@ -31,7 +29,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)
@@ -89,10 +88,8 @@ print(response.text)
 > Sample request:
 
 ```shell
-curl -X PUT -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
-    "name": "new name "
-
+curl -X PUT -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
+    "name": "new name"
 }' "https://api.apollo.io/v1/accounts/YOUR_ACCOUNT_ID"
 ```
 
@@ -102,13 +99,13 @@ import requests
 url = "https://api.apollo.io/v1/accounts/YOUR_ACCOUNT_ID"
 
 data = {
-  "api_key": "YOUR API KEY HERE",
-  "name": "new name ",
+  "name": "new name"
 }
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("PUT", url, headers=headers, json=data)
@@ -164,8 +161,7 @@ This endpoint takes a `YOUR_ACCOUNT_ID` field at the end of the request URL to u
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "q_organization_name": "Google",
     "sort_by_field": "account_last_activity_date",
     "sort_ascending": false
@@ -178,7 +174,6 @@ import requests
 url = "https://api.apollo.io/v1/accounts/search"
 
 data = {
-  "api_key": "YOUR API KEY HERE",
     "q_organization_name": "Google",
     "sort_by_field": "account_last_activity_date",
     "sort_ascending": False
@@ -186,7 +181,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)
@@ -303,7 +299,7 @@ This feature is not accessible to Apollo users on free plans.
 > Sample request:
 
 ```shell
-curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" "https://api.apollo.io/v1/account_stages?api_key=YOUR_API_KEY_HERE"
+curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" "https://api.apollo.io/v1/account_stages"
 ```
 
 ```python
@@ -311,16 +307,13 @@ import requests
 
 url = "https://api.apollo.io/v1/account_stages"
 
-querystring = {
-  "api_key": "YOUR API KEY HERE"
-}
-
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
-response = requests.request("GET", url, headers=headers, params=querystring)
+response = requests.request("GET", url, headers=headers)
 
 print(response.text)
 ```
@@ -386,8 +379,7 @@ print(response.text)
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "account_ids": ["account_id1", "account_id2"],
     "account_stage_id": "stage_id"
 }' "https://api.apollo.io/v1/accounts/bulk_update"
@@ -399,14 +391,14 @@ import requests
 url = "https://api.apollo.io/v1/accounts/bulk_update"
 
 data = {
-  "api_key": "YOUR API KEY HERE",
     "account_ids": ["account_id1", "account_id2"],
     "account_stage_id": "stage_id"
 }
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)
@@ -441,8 +433,7 @@ print(response.text)
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "account_ids": ["account_id1", "account_id2"],
     "owner_id": "owner_id"
 }' "https://api.apollo.io/v1/accounts/update_owners"
@@ -454,14 +445,14 @@ import requests
 url = "https://api.apollo.io/v1/accounts/update_owners"
 
 data = {
-  "api_key": "YOUR API KEY HERE",
     "account_ids": ["account_id1", "account_id2"],
     "owner_id": "owner_id"
 }
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)

--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -5,7 +5,7 @@
 
 ```shell
 # With shell, you can just pass the correct header with each request
-curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" "https://api.apollo.io/v1/auth/health?api_key=YOUR_API_KEY_HERE"
+curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" "https://api.apollo.io/v1/auth/health"
 ```
 
 ```python
@@ -13,16 +13,13 @@ import requests
 
 url = "https://api.apollo.io/v1/auth/health"
 
-querystring = {
-    "api_key": "YOUR API KEY HERE"
-}
-
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
-response = requests.request("GET", url, headers=headers, params=querystring)
+response = requests.request("GET", url, headers=headers)
 
 print(response.text)
 ```

--- a/source/includes/_contacts.md
+++ b/source/includes/_contacts.md
@@ -7,8 +7,7 @@ A contact is a person your team has explicitly added to your database. It can be
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "first_name": "Jon",
     "last_name": "Snow",
     "title": "Lord Commander",
@@ -22,7 +21,6 @@ import requests
 url = "https://api.apollo.io/v1/contacts"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "first_name": "Jonny",
     "last_name": "Snow",
     "title": "Lord Commander",
@@ -31,7 +29,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)
@@ -140,8 +139,7 @@ other_phone | Phone of unknown type for this contact. | "123-456-7890"
 > Sample request:
 
 ```shell
-curl -X PUT -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X PUT -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "first_name": "Jon",
     "last_name": "Snow",
     "email": "jon.snow@westeros.com",
@@ -156,7 +154,6 @@ import requests
 url = "https://api.apollo.io/v1/contacts/YOUR_CONTACT_ID"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "first_name": "Jon",
     "last_name": "Snow",
     "email": "jon.snow@westeros.com",
@@ -166,7 +163,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("PUT", url, headers=headers, json=data)
@@ -277,8 +275,7 @@ other_phone | Phone of unknown type for this contact. If the contact already has
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "q_keywords": "Tim Zheng, CEO, Apollo",
     "sort_by_field": "contact_last_activity_date",
     "sort_ascending": false
@@ -291,7 +288,6 @@ import requests
 url = "https://api.apollo.io/v1/contacts/search"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "q_keywords": "Tim Zheng, CEO, Apollo",
     "sort_by_field": "contact_last_activity_date",
     "sort_ascending": False,
@@ -299,7 +295,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)
@@ -474,7 +471,7 @@ page | Which page to return. Defaults to 1
 > Sample request:
 
 ```shell
-curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" "https://api.apollo.io/v1/contact_stages?api_key=YOUR_API_KEY_HERE"
+curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" "https://api.apollo.io/v1/contact_stages"
 ```
 
 ```python
@@ -482,16 +479,13 @@ import requests
 
 url = "https://api.apollo.io/v1/contact_stages"
 
-querystring = {
-    "api_key": "YOUR API KEY HERE"
-}
-
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
-response = requests.request("GET", url, headers=headers, params=querystring)
+response = requests.request("GET", url, headers=headers)
 
 print(response.text)
 ```
@@ -594,8 +588,7 @@ print(response.text)
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "contact_ids": ["contact_id1", "contact_id2"],
     "contact_stage_id": "stage_id"
 }' "https://api.apollo.io/v1/contacts/update_stages"
@@ -607,14 +600,14 @@ import requests
 url = "https://api.apollo.io/v1/contacts/update_stages"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "contact_ids": ["contact_id1", "contact_id2"],
     "contact_stage_id": "stage_id"
 }
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)
@@ -700,8 +693,7 @@ contact_stage_id | The contact stage id to change into. You can GET a list of po
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "contact_ids": ["contact_id1", "contact_id2"],
     "owner_id": "owner_id"
 }' "https://api.apollo.io/v1/contacts/update_owners"
@@ -713,14 +705,14 @@ import requests
 url = "https://api.apollo.io/v1/contacts/update_owners"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "contact_ids": ["contact_id1", "contact_id2"],
     "owner_id": "owner_id"
 }
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)

--- a/source/includes/_enrichment.md
+++ b/source/includes/_enrichment.md
@@ -3,8 +3,7 @@
 ## Bulk people enrichment
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "reveal_personal_emails": true,
     "details": [
         {
@@ -34,7 +33,6 @@ import requests
 url = "https://api.apollo.io/api/v1/people/bulk_match"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "reveal_personal_emails": true,
     "details": [
         {
@@ -59,7 +57,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)
@@ -541,8 +540,7 @@ webhook_url (optional) | Webhook URL for sending 'reveal_phone_number' response 
 ## Bulk organization enrichment
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "domains": [
         "apollo.io",
         "outreach.com",
@@ -557,7 +555,6 @@ import requests
 url = "https://api.apollo.io/api/v1/organizations/bulk_enrich"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "domains": [
         "apollo.io",
         "outreach.com",
@@ -567,7 +564,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)
@@ -912,8 +910,7 @@ Rate limits on this endpoint are 1/10th of what is available on the single enric
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "id": "583f2f7ed9ced98ab5bfXXXX",
     "first_name": "Tim",
     "last_name": "Zheng",
@@ -932,7 +929,6 @@ import requests
 url = "https://api.apollo.io/v1/people/match"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "id": "583f2f7ed9ced98ab5bfXXXX",
     "first_name": "Tim",
     "last_name": "Zheng",
@@ -946,7 +942,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)
@@ -1214,7 +1211,7 @@ webhook_url (optional) | Webhook URL for sending 'reveal_phone_number' response 
 > Sample request:
 
 ```shell
-curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" "https://api.apollo.io/v1/organizations/enrich?api_key=YOUR_API_KEY_HERE&domain=apollo.io"
+curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" "https://api.apollo.io/v1/organizations/enrich?domain=apollo.io"
 ```
 
 ```python
@@ -1223,13 +1220,13 @@ import requests
 url = "https://api.apollo.io/v1/organizations/enrich"
 
 querystring = {
-    "api_key": "YOUR API KEY HERE",
     "domain": "apollo.io"
 }
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("GET", url, headers=headers, params=querystring)

--- a/source/includes/_misc.md
+++ b/source/includes/_misc.md
@@ -5,7 +5,7 @@
 > Sample request:
 
 ```shell
-curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" "https://api.apollo.io/v1/users/search?api_key=YOUR_API_KEY_HERE"
+curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" "https://api.apollo.io/v1/users/search"
 ```
 
 ```python
@@ -13,16 +13,13 @@ import requests
 
 url = "https://api.apollo.io/v1/users/search"
 
-querystring = {
-    "api_key": "YOUR API KEY HERE"
-}
-
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
-response = requests.request("GET", url, headers=headers, params=querystring)
+response = requests.request("GET", url, headers=headers)
 
 print(response.text)
 ```
@@ -260,7 +257,7 @@ This feature is not accessible to Apollo users on free plans.
 > Sample request:
 
 ```shell
-curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" "https://api.apollo.io/v1/email_accounts?api_key=YOUR_API_KEY_HERE"
+curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" "https://api.apollo.io/v1/email_accounts"
 ```
 
 ```python
@@ -268,16 +265,13 @@ import requests
 
 url = "https://api.apollo.io/v1/email_accounts"
 
-querystring = {
-    "api_key": "YOUR API KEY HERE"
-}
-
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
-response = requests.request("GET", url, headers=headers, params=querystring)
+response = requests.request("GET", url, headers=headers)
 
 print(response.text)
 ```
@@ -321,7 +315,7 @@ print(response.text)
 > Sample request:
 
 ```shell
-curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" "https://api.apollo.io/v1/labels?api_key=YOUR_API_KEY_HERE"
+curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" "https://api.apollo.io/v1/labels"
 ```
 
 ```python
@@ -329,16 +323,13 @@ import requests
 
 url = "https://api.apollo.io/v1/labels"
 
-querystring = {
-    "api_key": "YOUR API KEY HERE"
-}
-
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
-response = requests.request("GET", url, headers=headers, params=querystring)
+response = requests.request("GET", url, headers=headers)
 
 print(response.text)
 ```
@@ -394,7 +385,7 @@ print(response.text)
 > Sample request:
 
 ```shell
-curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" "https://api.apollo.io/v1/typed_custom_fields?api_key=YOUR_API_KEY_HERE"
+curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" "https://api.apollo.io/v1/typed_custom_fields"
 ```
 
 ```python
@@ -402,16 +393,13 @@ import requests
 
 url = "https://api.apollo.io/v1/typed_custom_fields"
 
-querystring = {
-    "api_key": "YOUR API KEY HERE"
-}
-
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
-response = requests.request("GET", url, headers=headers, params=querystring)
+response = requests.request("GET", url, headers=headers)
 
 print(response.text)
 ```
@@ -608,7 +596,7 @@ print(response.text)
 > Sample request:
 
 ```shell
-curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" "https://api.apollo.io/v1/opportunity_stages?api_key=YOUR_API_KEY_HERE"
+curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" "https://api.apollo.io/v1/opportunity_stages"
 ```
 
 ```python
@@ -616,16 +604,13 @@ import requests
 
 url = "https://api.apollo.io/v1/opportunity_stages"
 
-querystring = {
-    "api_key": "YOUR API KEY HERE"
-}
-
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
-response = requests.request("GET", url, headers=headers, params=querystring)
+response = requests.request("GET", url, headers=headers)
 
 print(response.text)
 ```

--- a/source/includes/_opportunities.md
+++ b/source/includes/_opportunities.md
@@ -8,8 +8,7 @@ Opportunities can be associated with both companies and people in Apollo.
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "owner_id":"5c10XXXXXXXXXXXXXXXXXXXX",
     "name":"Opportunity Name",
     "amount":"200",
@@ -25,7 +24,6 @@ import requests
 url = "https://app.apollo.io/api/v1/opportunities"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "owner_id":"5c10XXXXXXXXXXXXXXXXXXXX",
     "name":"Opportunity Name",
     "amount":"200",
@@ -36,7 +34,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)
@@ -86,7 +85,7 @@ print(response.text)
 > Sample request:
 
 ```shell
-curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" "https://api.apollo.io/v1/opportunities/search?api_key=YOUR_API_KEY_HERE"
+curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" "https://api.apollo.io/v1/opportunities/search"
 ```
 
 ```python
@@ -94,16 +93,13 @@ import requests
 
 url = "https://api.apollo.io/v1/opportunities/search"
 
-querystring = {
-    "api_key": "YOUR API KEY HERE"
-}
-
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
-response = requests.request("GET", url, headers=headers, params=querystring)
+response = requests.request("GET", url, headers=headers)
 
 print(response.text)
 ```
@@ -237,7 +233,7 @@ This endpoint returns all opportunities you have created.
 > Sample request:
 
 ```shell
-curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" "https://api.apollo.io/v1/opportunities/REPLACE_WITH_OPPORTUNITY_ID?api_key=YOUR_API_KEY_HERE"
+curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" "https://api.apollo.io/v1/opportunities/REPLACE_WITH_OPPORTUNITY_ID"
 ```
 
 ```python
@@ -245,16 +241,13 @@ import requests
 
 url = "https://api.apollo.io/v1/opportunities/REPLACE_WITH_OPPORTUNITY_ID"
 
-querystring = {
-    "api_key": "YOUR API KEY HERE"
-}
-
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
-response = requests.request("GET", url, headers=headers, params=querystring)
+response = requests.request("GET", url, headers=headers)
 
 print(response.text)
 ```
@@ -300,8 +293,7 @@ You can GET a list of all created opportunities from [opportunities/all](#get-al
 > Sample request:
 
 ```shell
-curl -X PATCH -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X PATCH -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "name": "Opportunity Name Updated",
 }' "https://api.apollo.io/v1/opportunities"
 ```
@@ -312,13 +304,13 @@ import requests
 url = "https://api.apollo.io/v1/opportunities"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "name": "Opportunity Name Updated",
 }
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.patch(url, headers=headers, data=data)

--- a/source/includes/_organizations.md
+++ b/source/includes/_organizations.md
@@ -7,7 +7,7 @@ An organization represents a company in Apollo's database.
 > Sample request:
 
 ```shell
-curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" "https://api.apollo.io/v1/organizations/ORGANIZATION_ID/job_postings?api_key=YOUR_API_KEY_HERE"
+curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" "https://api.apollo.io/v1/organizations/ORGANIZATION_ID/job_postings"
 ```
 
 ```python
@@ -15,16 +15,13 @@ import requests
 
 url = "https://api.apollo.io/v1/organizations/ORGANIZATION_ID/job_postings"
 
-querystring = {
-    "api_key": "YOUR API KEY HERE"
-}
-
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
-response = requests.request("GET", url, headers=headers, params=querystring)
+response = requests.request("GET", url, headers=headers)
 
 print(response.text)
 ```
@@ -85,8 +82,7 @@ Get a list of active job postings for a company.
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-  "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
   "page": 1,
   "per_page": 10,
   "organization_num_employees_ranges": ["1,100", "1,1000"],
@@ -102,7 +98,6 @@ import requests
 url = "https://api.apollo.io/api/v1/mixed_companies/search"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "page":1,
     "per_page":10,  
     "organization_num_employees_ranges":["1,100", "1,1000"],
@@ -113,7 +108,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)

--- a/source/includes/_people.md
+++ b/source/includes/_people.md
@@ -7,8 +7,7 @@ A person represents a person in Apollo's database.
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "q_organization_domains": "apollo.io\ngoogle.com",
     "page" : 1,
     "per_page": 10,
@@ -25,7 +24,6 @@ import requests
 url = "https://api.apollo.io/v1/mixed_people/search"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "q_organization_domains": "apollo.io\ngoogle.com",
     "page" : 1,
     "per_page": 10,
@@ -37,7 +35,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)

--- a/source/includes/_sequences.md
+++ b/source/includes/_sequences.md
@@ -7,8 +7,7 @@ Use the sequences API to interact with sequences, add contacts to sequence, and 
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "q_name": "Sequence Name"
 }' "https://api.apollo.io/v1/emailer_campaigns/search"
 ```
@@ -19,13 +18,13 @@ import requests
 url = "https://api.apollo.io/v1/emailer_campaigns/search"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "q_name": "Sequence Name"
 }
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)
@@ -129,8 +128,7 @@ q_name| Name | "Name of Sequence"
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "async": false,
     "contact_ids": ["contact id 1", "contact id 2"],
     "emailer_campaign_id": REPLACE_WITH_SEQUENCE_ID,
@@ -151,7 +149,6 @@ import requests
 url = "https://api.apollo.io/v1/emailer_campaigns/REPLACE_WITH_SEQUENCE_ID/add_contact_ids"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "async": False,
     "contact_ids": ["contact id 1", "contact id 2"],
     "emailer_campaign_id": REPLACE_WITH_SEQUENCE_ID,
@@ -166,7 +163,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)
@@ -353,8 +351,7 @@ user_id | User who is performing this action | 5cc77dXXXXXXXXXXXXXXXXXX
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "emailer_campaign_ids": ["contact id 1", "contact id 2"],
     "contact_ids": ["contact id 1", "contact id 2"],
     "mode": "remove",
@@ -368,7 +365,6 @@ import requests
 url = "https://api.apollo.io/v1/emailer_campaigns/remove_or_stop_contact_ids"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "emailer_campaign_ids": ["contact id 1", "contact id 2"],
     "contact_ids": ["contact id 1", "contact id 2"],
     "mode": "remove",
@@ -377,7 +373,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)

--- a/source/includes/_tasks.md
+++ b/source/includes/_tasks.md
@@ -7,7 +7,7 @@ A task is an action to be performed on a contact, The task can be assigned to an
 > Sample request:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
+curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "priority": "medium",
     "user_id": "5c10XXXXXXXXXXXXXXXXXXXX",
     "due_at": "2020-12-21T16:16:48.311Z",
@@ -27,7 +27,6 @@ import requests
 url = "https://api.apollo.io/v1/tasks/bulk_create"
 
 data = {
-    "api_key": "YOUR API KEY HERE",
     "priority": "medium",
     "user_id": "5c10XXXXXXXXXXXXXXXXXXXX",
     "due_at": "2020-12-21T16:16:48.311Z",
@@ -42,7 +41,8 @@ data = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("POST", url, headers=headers, json=data)
@@ -75,8 +75,7 @@ print(response.text)
 > Sample request:
 
 ```shell
-curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
-    "api_key": "YOUR API KEY HERE",
+curl -X GET -H "Content-Type: application/json" -H "Cache-Control: no-cache" -H "X-Api-Key: YOUR API KEY HERE" -d '{
     "sort_by_field": "task_created_at",
     "per_page": 200,
     "open_factor_names": [
@@ -91,7 +90,6 @@ import requests
 url = "https://api.apollo.io/v1/tasks/search"
 
 querystring = {
-    "api_key": "YOUR API KEY HERE",
     "sort_by_field": "task_created_at",
     "open_factor_names": [
         "task_types"
@@ -100,7 +98,8 @@ querystring = {
 
 headers = {
     'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Api-Key': 'YOUR API KEY HERE'
 }
 
 response = requests.request("GET", url, headers=headers, params=querystring)


### PR DESCRIPTION
Description:
 
Reference Jira: https://apollopde.atlassian.net/browse/INCIDENT-8514
Parent Jira: https://apollopde.atlassian.net/browse/INCIDENT-8014

Parent PR Reference: https://github.com/apolloio/leadgenie/pull/29130

1. We have made changes to behaviour of accepting the Api Keys via params to request headers due to a security concern INCIDENT-8014.
2. For a 4 months of grace period Api Keys will be accepted via both Query Params (for old customers) and via Request Headers ( for new customers).
3. In order to ensure the behaviour for new customers, we are updating the Api Doc to accept Api Key via request header 'X-Api-Key' and this behaviour will be a mandate for old customers as well after grace period expiry.