### PR TITLE
[LD-1386] Fix Python scripts and add reveal_phone_number + webhook-url fields

### DIFF
--- a/source/includes/_enrichment.md
+++ b/source/includes/_enrichment.md
@@ -950,7 +950,7 @@ data = {
     "linkedin_url": "http://www.linkedin.com/in/tim-zheng-677ba010",
     "reveal_personal_emails": True,
     "reveal_phone_number": True,
-    "webhook_url": "https://your_webhook_site",
+    "webhook_url": "https://your_webhook_site"
 }
 
 headers = {

--- a/source/includes/_enrichment.md
+++ b/source/includes/_enrichment.md
@@ -6,6 +6,8 @@
 curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
     "api_key": "YOUR API KEY HERE",
     "reveal_personal_emails": true,
+    "reveal_phone_number": true,
+    "webhook_url": "https://your_webhook_site"
     "details": [
         {
             "first_name": "Tim",
@@ -35,7 +37,9 @@ url = "https://api.apollo.io/api/v1/people/bulk_match"
 
 data = {
     "api_key": "YOUR API KEY HERE",
-    "reveal_personal_emails": true,
+    "reveal_personal_emails": True,
+    "reveal_phone_number": True,
+    "webhook_url": "https://your_webhook_site"
     "details": [
         {
             "first_name": "Tim",
@@ -43,7 +47,7 @@ data = {
             "domain": "apollo.io",
             "hashed_email": "8d935115b9ff4489f2d1f9249503cadf",
             "email": "tim@apollo.io",
-            "organization_name": "Apollo"
+            "organization_name": "Apollo",
             "linkedin_url": "http://www.linkedin.com/in/tim-zheng-677ba010"
         },
         {
@@ -51,7 +55,7 @@ data = {
             "last_name": "Chung",
             "email": "roy@apollo.io",
             "hashed_email": "97817c0c49994eb500ad0a5e7e2d8aed51977b26424d508f66e4e8887746a152",
-            "organization_name": "Apollo"
+            "organization_name": "Apollo",
             "linkedin_url": "http://www.linkedin.com/in/royychung"
         }
     ]
@@ -921,8 +925,11 @@ curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d
     "email": "name@domain.io",
     "hashed_email": "8d935115b9ff4489f2d1f9249503cadf",
     "domain": "apollo.io",
+    "linkedin_url": "http://www.linkedin.com/in/tim-zheng-677ba010",
     "reveal_personal_emails": true,
-    "linkedin_url": "http://www.linkedin.com/in/tim-zheng-677ba010"
+    "reveal_phone_number": true,
+    "webhook_url": "https://your_webhook_site"
+    
 }' "https://api.apollo.io/v1/people/match"
 ```
 
@@ -940,8 +947,10 @@ data = {
     "email": "name@domain.io",
     "hashed_email": "8d935115b9ff4489f2d1f9249503cadf",
     "domain": "apollo.io",
-    "reveal_personal_emails": true,
-    "linkedin_url": "http://www.linkedin.com/in/tim-zheng-677ba010"
+    "linkedin_url": "http://www.linkedin.com/in/tim-zheng-677ba010",
+    "reveal_personal_emails": True,
+    "reveal_phone_number": True,
+    "webhook_url": "https://your_webhook_site",
 }
 
 headers = {

--- a/source/includes/_enrichment.md
+++ b/source/includes/_enrichment.md
@@ -7,7 +7,7 @@ curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d
     "api_key": "YOUR API KEY HERE",
     "reveal_personal_emails": true,
     "reveal_phone_number": true,
-    "webhook_url": "https://your_webhook_site"
+    "webhook_url": "https://your_webhook_site",
     "details": [
         {
             "first_name": "Tim",
@@ -39,7 +39,7 @@ data = {
     "api_key": "YOUR API KEY HERE",
     "reveal_personal_emails": True,
     "reveal_phone_number": True,
-    "webhook_url": "https://your_webhook_site"
+    "webhook_url": "https://your_webhook_site",
     "details": [
         {
             "first_name": "Tim",


### PR DESCRIPTION
Make sure you've checked off all these things before submitting:
https://apollopde.atlassian.net/browse/LD-1386
Core Incident: https://apollopde.atlassian.net/browse/INCIDENT-8522

1. Fix Python script errors in Docs
2. Add `reveal_phone_number` and `webhook_url` field


Before:
<img width="737" alt="Screenshot 2024-05-06 at 2 10 43 PM" src="https://github.com/apolloio/apollo-api-docs/assets/54931749/8daeffbf-f9f3-48ad-883f-ef8228422db8">

<img width="747" alt="Screenshot 2024-05-06 at 2 10 55 PM" src="https://github.com/apolloio/apollo-api-docs/assets/54931749/5cd205dc-8d0a-432b-8f18-9f87c391caff">

After
<img width="749" alt="Screenshot 2024-05-06 at 2 11 22 PM" src="https://github.com/apolloio/apollo-api-docs/assets/54931749/7ae0a560-7726-4292-abe9-b81d535c9fbb">

<img width="750" alt="Screenshot 2024-05-06 at 2 11 33 PM" src="https://github.com/apolloio/apollo-api-docs/assets/54931749/d26daf85-e7c1-4e67-882f-96d1b0a9fe74">


- [x] This pull request isn't for a company's fork, it's intended for the upstream Slate shared by everybody.
- [x] This pull request is submitted to the `master` branch.
- [x] If it makes frontend changes, this pull request has been tested in the latest version of Firefox, Chrome, IE, and Safari.
- [x] If it is an API related fix, the shell and python code have been tested
